### PR TITLE
Fix to use Drupal once library

### DIFF
--- a/js/islandora_install_profile_demo_core.js
+++ b/js/islandora_install_profile_demo_core.js
@@ -11,7 +11,7 @@
         return response;
       }
 
-      $('select[name="sort_order"]').once('islandora_install_profile_demo_core_actions').change(function () {
+      $(once('islandora_install_profile_demo_core_actions','select[name="sort_order"]')).change(function () {
         // Grab ALL elements from the URL and re-use them with this one request
         let existing_parameters = unserialize(location.search.slice(1));
         let selected_option = 'select[name="sort_order"] option[value="' + $(this).val() + '"]';

--- a/views_nested_details.libraries.yml
+++ b/views_nested_details.libraries.yml
@@ -6,6 +6,6 @@ mystic_behaviors:
       css/islandora_install_profile_demo_core.css: { }
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/once
     - core/drupal.ajax
     - core/views.ajax


### PR DESCRIPTION
This replaces calls to jquery once function with the Drupal once function for Drupal 10 compatibility.

To test add newspaper objects ( I used the Newspapers and Serials from here: https://github.com/Islandora-Devops/islandora_demo_objects) and errors should show up like the example below in the console.
TypeError: $(...).once is not a function
    at Object.attach
Pull in the pr and the errors should not show up anymore in the console.